### PR TITLE
Document asset scripts

### DIFF
--- a/admin/assets.php
+++ b/admin/assets.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Asset Management Dashboard
+ * --------------------------
+ * Presents a searchable, filterable view of non-inventory assets for
+ * administrators. The page loads the shared header to enforce session and
+ * translation handling, verifies access, and then renders a Bootstrap grid
+ * backed by the server-side DataTable implemented in
+ * `assets/js/assets.js`. CRUD submissions are routed to
+ * `ajax/process_asset.php`, while the initial table data and edit modals read
+ * from `ajax/get_assets.php`/`ajax/get_asset.php` to keep the UI reactive.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/barcode.php
+++ b/admin/barcode.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Barcode Generation Console
+ * --------------------------
+ * Allows inventory-privileged administrators to generate printable barcode
+ * sheets for catalog items. The page enforces authentication, loads catalog
+ * metadata for selection, and renders preview/print controls that embed
+ * responses from `admin/barcode_image.php`. Client-side interactions are
+ * handled in `assets/js/barcode-render.js`, which requests the chosen format
+ * and duplicates of the barcode for rapid label printing.
+ */
 // admin/barcode.php
 require_once __DIR__ . '/../includes/session_config.php';
 

--- a/admin/barcode_image.php
+++ b/admin/barcode_image.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Barcode Rendering Helper
+ * ------------------------
+ * Invoked inside `admin/barcode.php` to output the selected barcode format as
+ * inline HTML or an image tag. The script wires up the Picqer barcode
+ * generator library, constrains rendering to the Code128 variants used across
+ * the application, and echoes markup combined with a human-readable barcode
+ * caption. Front-end scripts embed this endpoint inside iframes to preview and
+ * print batches of labels without exposing the PHP barcode library directly in
+ * the browser bundle.
+ */
 // admin/barcode_image.php
 $barcode = $_GET['barcode'] ?? '';
 $format = $_GET['format'] ?? 'png';

--- a/admin/box_comparison.php
+++ b/admin/box_comparison.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Box Quantity Comparison Dashboard
+ * ---------------------------------
+ * Provides procurement and warehouse teams with a real-time comparison between
+ * the quantities recorded when containers were unpacked and the current stock
+ * levels stored in warehouse boxes. The page leverages the header bootstrap for
+ * authentication, exposes CSRF tokens for AJAX calls, and relies on
+ * `assets/js/boxes.js` in combination with `ajax/get_box_comparison.php` to
+ * populate statistic cards, charts, and discrepancy tables for reconciliation
+ * work.
+ */
 ob_start();
 require_once '../includes/header.php';
 

--- a/admin/boxes.php
+++ b/admin/boxes.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Warehouse Box Management
+ * ------------------------
+ * Enables inventory administrators to review and maintain warehouse box
+ * records, including status, container linkage, and item capacity. After the
+ * shared header enforces authentication, the page renders filters, statistics,
+ * and modal-driven CRUD forms orchestrated by `assets/js/boxes.js`. All data
+ * interactions are delegated to endpoints such as `ajax/get_boxes.php` and
+ * `ajax/process_boxes.php`, while a CSRF token is embedded for the JavaScript
+ * client to include in each request.
+ */
 ob_start();
 require_once '../includes/header.php';
 

--- a/admin/categories.php
+++ b/admin/categories.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Category Administration
+ * -----------------------
+ * Provides administrators and inventory managers with tools to manage product
+ * category metadata. The page enforces authentication via the shared header,
+ * seeds CSRF tokens for AJAX interactions, and renders a DataTable driven by
+ * `assets/js/categories.js`. Create/update/delete operations are executed
+ * through `ajax/process_category.php`, while the listing and edit forms pull
+ * from `ajax/get_categories.php` and `ajax/get_category.php` respectively.
+ */
 require_once '../includes/header.php';
 
 if (!is_logged_in()) {

--- a/admin/containers.php
+++ b/admin/containers.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Container Lifecycle Management
+ * ------------------------------
+ * Centralizes procurement container workflows for administrators. The page
+ * bootstraps session security, restricts access to the admin role, and renders
+ * advanced filters plus modal-driven forms for creating, editing, and
+ * processing container shipments. JavaScript coordination lives in
+ * `assets/js/containers.js`, which consumes endpoints like
+ * `ajax/get_containers.php`, `ajax/get_container.php`, and
+ * `ajax/process_container.php` to manage nested cost breakdowns, item imports,
+ * analytics, and status transitions.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Administrator Landing Dashboard
+ * -------------------------------
+ * Presents high-level metrics and recent activity tables for administrators as
+ * soon as they log in. The layout is intentionally mobile-friendly, loading
+ * placeholder values that are asynchronously hydrated by
+ * `assets/js/admin_dashboard.js` via `ajax/admin_dashboard.php`. Access is
+ * restricted to admin roles, and the shared header ensures language and
+ * security bootstrapping before the cards and tables are rendered.
+ */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);

--- a/admin/expenses.php
+++ b/admin/expenses.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Administrative Expense Oversight
+ * --------------------------------
+ * Equips administrators with a consolidated view of expense submissions across
+ * all stores. The page loads the shared header for authentication, exposes
+ * filters for store, status, and date ranges, and renders a DataTable managed by
+ * `assets/js/admin_expenses.js`. Expense records are fetched through
+ * `ajax/store_expenses.php`, while approvals and edits are processed via
+ * `ajax/process_expense.php` to keep accounting controls centralized.
+ */
 require_once '../includes/header.php';
 if (!is_admin()) {
     redirect('../index.php');

--- a/admin/inventory.php
+++ b/admin/inventory.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Legacy Inventory Management Console
+ * -----------------------------------
+ * Provides the classic inventory grid used by administrators and inventory
+ * managers to inspect catalog items, trigger incoming stock workflows, and
+ * launch transfer modals. While largely superseded by `admin/store_items.php`,
+ * the page still wires up the shared header for authentication, exposes
+ * DataTable filters, and delegates client-side orchestration to
+ * `assets/js/inventory.js` together with endpoints like
+ * `ajax/get_inventory.php` and `ajax/process_inventory.php`.
+ */
 ob_start();
 require_once '../includes/header.php';
 

--- a/admin/invoices.php
+++ b/admin/invoices.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Global Invoice Browser
+ * ----------------------
+ * Gives administrators access to search and review invoices generated across
+ * all stores. After establishing the hardened session and header, the page
+ * renders advanced filters and a modal-driven detail viewer coordinated by
+ * `assets/js/invoices.js`. DataTable results flow from `ajax/get_invoices.php`,
+ * while invoice detail modals consume `ajax/get_invoice.php` to display line
+ * items and payments for auditing.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/maintenance.php
+++ b/admin/maintenance.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Preventive Maintenance Scheduler
+ * --------------------------------
+ * Lets administrators coordinate recurring maintenance tasks across assets.
+ * The page validates authentication, optionally hydrates context for a specific
+ * asset, and surfaces forms for defining recurrence, technician assignments, and
+ * reminders. `assets/js/maintenance.js` powers the client experience, pulling
+ * schedule data from `ajax/get_maintenance.php`, fetching asset metadata, and
+ * submitting CRUD operations to `ajax/process_maintenance.php`.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/maintenance_history.php
+++ b/admin/maintenance_history.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Maintenance History Viewer
+ * --------------------------
+ * Surfaces historical maintenance records for assets and schedules, enabling
+ * administrators to audit completed tasks, technician notes, and costs. The
+ * page can be pre-filtered via query parameters, retrieves associated names for
+ * context, and renders an interactive timeline via `assets/js/maintenance_history.js`.
+ * History entries are loaded from `ajax/get_maintenance_history.php`, while
+ * follow-up updates leverage `ajax/process_maintenance_history.php` for
+ * consistency with the scheduler module.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/purchase_orders.php
+++ b/admin/purchase_orders.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Purchase Order Management Workspace
+ * -----------------------------------
+ * Hosts the administrative interface for creating, editing, and monitoring
+ * purchase orders. After the shared session bootstrap, the page renders
+ * supplier/status/date filters, a server-side DataTable, and modal forms that
+ * capture PO headers and line items. The interactive behavior is implemented in
+ * `assets/js/purchase_orders.js`, which calls `ajax/get_purchase_orders.php`
+ * for listings, `ajax/get_purchase_order.php` for detail views, and
+ * `ajax/process_purchase_order.php` to persist changes.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/reports.php
+++ b/admin/reports.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Administrative Reporting Hub
+ * -----------------------------
+ * Serves as the configurable reporting surface for administrators, aggregating
+ * sales, inventory, transfer, and financial data based on the selected report
+ * type and date/time filters. The page runs bespoke SQL queries directly to
+ * produce tabular summaries and charts, while also delegating some datasets to
+ * asynchronous requests consumed by `assets/js/store_reports.js`. Authentication
+ * and localization are ensured via the shared header before rendering the
+ * dynamic content.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/store_inventory.php
+++ b/admin/store_inventory.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Store Inventory Oversight
+ * ------------------------
+ * Allows admins, inventory managers, and authorized store managers to review
+ * per-store stock levels, adjust assignments, and inspect item health metrics.
+ * The page enforces role-based access, determines the default store scope, and
+ * renders cards plus DataTables powered by `assets/js/store_items.js` and
+ * related scripts. Data is sourced from endpoints like
+ * `ajax/get_store_inventory_enhanced.php` and actions route to
+ * `ajax/process_store_inventory.php` for adjustments.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/store_items.php
+++ b/admin/store_items.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Central Inventory & Store Assignment Manager
+ * --------------------------------------------
+ * Replaces the legacy inventory console with a combined workspace for catalog
+ * maintenance and store assignment management. The page enforces inventory-role
+ * access, embeds CSRF tokens for JavaScript submissions, and renders advanced
+ * filters plus modals orchestrated by `assets/js/store_items.js`. Listing data
+ * is retrieved from `ajax/get_inventory.php`, while item CRUD and assignment
+ * updates interact with `ajax/process_store_items.php` and related endpoints.
+ */
 ob_start();
 require_once '../includes/header.php';
 

--- a/admin/stores.php
+++ b/admin/stores.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Store Directory Administration
+ * ------------------------------
+ * Provides administrators with CRUD controls for store metadata, including
+ * address details, phone contacts, and manager assignments. Authentication and
+ * CSRF protection are bootstrapped via the shared header, while
+ * `assets/js/stores.js` manages the DataTable, modal lifecycle, and AJAX
+ * submissions to `ajax/get_stores.php`, `ajax/get_store.php`, and
+ * `ajax/process_store.php`.
+ */
 require_once '../includes/header.php';
 
 if (!is_admin()) {

--- a/admin/subcategories.php
+++ b/admin/subcategories.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Subcategory Administration
+ * --------------------------
+ * Complements the category manager by allowing administrators and inventory
+ * managers to define subcategory taxonomy. The page enforces authentication via
+ * the header, seeds CSRF tokens for JavaScript requests, and presents filters
+ * plus modals coordinated by `assets/js/subcategories.js`. CRUD actions are
+ * served through `ajax/process_subcategory.php`, while listings pull from
+ * `ajax/get_subcategories.php` and `ajax/get_subcategory.php`.
+ */
 require_once '../includes/header.php';
 
 if (!is_logged_in()) {

--- a/admin/suppliers.php
+++ b/admin/suppliers.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Supplier Relationship Management
+ * --------------------------------
+ * Provides the administrative interface for maintaining supplier records,
+ * including contact details, status flags, and notes that feed procurement
+ * workflows. After authentication via the shared header, the page renders a
+ * filterable DataTable and modals driven by `assets/js/suppliers.js`, which in
+ * turn communicate with `ajax/get_suppliers.php`, `ajax/get_supplier.php`, and
+ * `ajax/process_supplier.php` for CRUD operations.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/transfers.php
+++ b/admin/transfers.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Transfer Management Control Center
+ * ----------------------------------
+ * Coordinates warehouse and inter-store transfer workflows for authorized
+ * personnel. The page activates the hardened session, verifies that the user
+ * has transfer privileges, and renders filters plus modals for creating new
+ * transfers or reconciling shipments. Client-side logic in
+ * `assets/js/transfers.js` (and related bundles) interacts with endpoints such
+ * as `ajax/get_transfer_shipments.php`, `ajax/process_transfer_shipment.php`,
+ * and `ajax/process_store_to_store_transfer.php` to move inventory while
+ * maintaining audit trails.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/admin/users.php
+++ b/admin/users.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * User Administration Portal
+ * --------------------------
+ * Restricts access to administrators responsible for onboarding and managing
+ * system accounts. The page reuses the shared header for authentication,
+ * renders filter controls, and delegates modal-driven CRUD to
+ * `assets/js/admin_users.js`. Back-end data is provided by
+ * `ajax/admin_users.php`, which handles listing, creation, updates, and
+ * password resets.
+ */
 require_once '../includes/header.php';
 if (!is_admin()) {
     redirect('../index.php');

--- a/admin/work_orders.php
+++ b/admin/work_orders.php
@@ -1,4 +1,15 @@
 <?php
+/**
+ * Work Order Coordination Center
+ * ------------------------------
+ * Bridges maintenance schedules and ad-hoc asset issues by allowing
+ * administrators to create, assign, and close work orders. The page handles
+ * optional pre-selection of assets or schedules, renders contextual metadata,
+ * and relies on `assets/js/work_orders.js` to drive the DataTable and modal
+ * flows. Data is exchanged with `ajax/get_work_orders.php`,
+ * `ajax/get_work_order.php`, and `ajax/process_work_order.php` to ensure
+ * consistent tracking of technician feedback and completion notes.
+ */
 ob_start();
 require_once '../includes/session_config.php';
 session_start();

--- a/ajax/admin_dashboard.php
+++ b/ajax/admin_dashboard.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Admin dashboard data provider.
+ *
+ * Accepts an `action` query parameter (`stats`, `recent_sales`, `low_stock`) and
+ * returns JSON responses that populate the administrator landing page cards and
+ * tables. Each branch performs role checks, runs the relevant aggregate SQL
+ * query, and standardizes the response structure to `{ success, data }` so the
+ * front-end can render the payload without additional transformation.
+ */
 ini_set('display_errors', 1);
 ini_set('display_startup_errors', 1);
 error_reporting(E_ALL);

--- a/ajax/admin_users.php
+++ b/ajax/admin_users.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Administrative user management endpoint.
+ *
+ * Provides server-side support for the admin users DataTable, handling list,
+ * create, update, and delete actions via the `action` parameter. Requests are
+ * restricted to authenticated admins, expect CSRF tokens for mutating flows,
+ * and respond with JSON structures consumed by `assets/js/admin_users.js`.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/ajax_session_init.php
+++ b/ajax/ajax_session_init.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Shared bootstrap for AJAX endpoints.
+ *
+ * Configures strict error reporting, loads session hardening defaults,
+ * initializes translation utilities when needed, and ensures every endpoint
+ * responds with JSON by default. Including files rely on this bootstrap before
+ * running any business logic to guarantee consistent authentication and locale
+ * handling.
+ */
 // Turn off error reporting to prevent HTML output
 error_reporting(0);
 ini_set('display_errors', 0);

--- a/ajax/check_db.php
+++ b/ajax/check_db.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Lightweight database health check.
+ *
+ * Attempts to connect to MySQL using the shared connection helper and returns
+ * a JSON status payload. Designed for uptime monitors or installer scripts to
+ * verify connectivity without requiring authentication.
+ */
 header('Content-Type: application/json');
 
 // Include database connection

--- a/ajax/close_shift.php
+++ b/ajax/close_shift.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Manual shift closure endpoint.
+ *
+ * Allows authenticated store personnel to close their active shift on demand.
+ * Validates CSRF tokens, summarizes the shift using helpers from
+ * `includes/shift_functions.php`, persists the closure, and returns the same
+ * summary structure used by the enforced logout modal.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/delete_transfer.php
+++ b/ajax/delete_transfer.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Transfer deletion handler.
+ *
+ * Reverses a previously recorded transfer shipment by restoring source
+ * inventory, decrementing destination stock, and cleaning up transfer-related
+ * records. Guarded for admin/warehouse roles and wraps operations in
+ * transactions to maintain stock integrity.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/enforced_logout.php
+++ b/ajax/enforced_logout.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Enforced logout data provider.
+ *
+ * When a store user attempts to log out, this endpoint ensures any open shift
+ * is summarized and optionally closed. Returns totals for sales, expenses,
+ * returns, and shift duration so the logout modal can display the information
+ * and require acknowledgement before the session ends.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/flutter_session.php
+++ b/ajax/flutter_session.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * Mobile client session bootstrapper.
+ *
+ * Lightweight authentication endpoint tailored for the Flutter application.
+ * Validates supplied credentials, establishes a PHP session, and returns the
+ * minimal user profile alongside a CSRF token so subsequent API calls can reuse
+ * the established session context.
+ */
 require_once '../includes/session_config.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/generate_shift_report.php
+++ b/ajax/generate_shift_report.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * On-demand shift report endpoint.
+ *
+ * Produces the same summary metrics available at shift closure—sales by
+ * payment method, returns, expenses, and duration—without changing the shift
+ * state. Used by the POS to let managers review live performance before
+ * closing out.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_asset.php
+++ b/ajax/get_asset.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Fetches a single asset record for editing dialogs.
+ *
+ * Requires admin authentication, validates the provided asset ID, and returns
+ * the asset fields as JSON so the admin UI can populate the edit modal.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_assets.php
+++ b/ajax/get_assets.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Server-side DataTable source for asset listings.
+ *
+ * Applies filters for category, location, status, and search terms while
+ * enforcing admin permissions. Returns a DataTables-compatible JSON payload
+ * consumed by `assets/js/assets.js`.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_box_comparison.php
+++ b/ajax/get_box_comparison.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Aggregates container box quantity comparisons.
+ *
+ * Computes differences between original container counts and current warehouse
+ * stock to highlight discrepancies on the procurement analytics page. Returns
+ * summary metrics and optional debugging metadata for admins.
+ */
 require_once '../includes/session_config.php';
 
 // Start session if not already started

--- a/ajax/get_boxes.php
+++ b/ajax/get_boxes.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Warehouse boxes DataTable provider.
+ *
+ * Delivers paginated, filterable box listings—including stats and dropdown
+ * options—for the warehouse management UI. Enforces admin/warehouse access and
+ * merges search filters with DataTables parameters before returning JSON.
+ */
 require_once '../includes/session_config.php';
 
 // Start session if not already started

--- a/ajax/get_categories.php
+++ b/ajax/get_categories.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Retrieves category listings for admin filters and dropdowns.
+ *
+ * Supports DataTable pagination and search, scopes results to active categories
+ * by default, and restricts access to authenticated admins before returning the
+ * JSON payload.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_category.php
+++ b/ajax/get_category.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Fetches a single category record.
+ *
+ * Used to populate the edit modal in the category management UI. Verifies admin
+ * privileges, validates the provided identifier, and returns the category row as
+ * JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_container.php
+++ b/ajax/get_container.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Retrieves procurement container header details.
+ *
+ * Supplies the edit modal in `admin/containers.php` with supplier linkage,
+ * status, cost breakdown, and scheduling metadata. Access is limited to admin
+ * users and results are returned as JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_container_analytics.php
+++ b/ajax/get_container_analytics.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Container analytics endpoint.
+ *
+ * Computes profitability, weight, and cost metrics for procurement containers
+ * so the dashboard can surface actionable insights. Results are filtered by the
+ * requesting admin’s criteria and delivered as JSON arrays.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_container_item_details.php
+++ b/ajax/get_container_item_details.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Provides detailed information for a specific container item.
+ *
+ * Returns box associations, cost breakdown, and quantity metrics for display in
+ * the container management modal. Access is restricted to admins and results
+ * are formatted as JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once dirname(__DIR__) . '/includes/db.php';
 require_once dirname(__DIR__) . '/includes/functions.php';

--- a/ajax/get_container_items.php
+++ b/ajax/get_container_items.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Lists all items tied to a procurement container.
+ *
+ * Feeds the nested tables in the container management UI by returning serialized
+ * item, box, and quantity data. Only administrators may call this endpoint and
+ * responses are emitted as JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_containers.php
+++ b/ajax/get_containers.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Server-side listing for procurement containers.
+ *
+ * Applies supplier, status, and date filters; composes statistics; and returns
+ * DataTables-compatible JSON used by `admin/containers.php`. Restricted to
+ * administrative roles.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_destination_store_items.php
+++ b/ajax/get_destination_store_items.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Supplies eligible destination store items for transfers.
+ *
+ * Ensures the requested items exist and are assignable at the destination
+ * store, returning results as JSON for the transfer creation modal.
+ */
 require_once '../includes/session_config.php';
 
 // Start session if not already started

--- a/ajax/get_inventory.php
+++ b/ajax/get_inventory.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Comprehensive inventory listing endpoint.
+ *
+ * Powers the admin inventory DataTable by joining catalog metadata, store stock
+ * levels, and container references. Applies search and filter criteria, enforces
+ * store scoping for non-admins, and outputs DataTables-friendly JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_invoice.php
+++ b/ajax/get_invoice.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Returns the full detail of a single invoice.
+ *
+ * Includes header, line items, payments, and metadata for display in admin and
+ * store invoice modals. Validates access permissions and responds with JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_invoices.php
+++ b/ajax/get_invoices.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Invoice DataTable endpoint.
+ *
+ * Supplies paginated invoice listings with optional store, status, and date
+ * filters. Supports both admin and store contexts while enforcing appropriate
+ * access control and outputting DataTables JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_item.php
+++ b/ajax/get_item.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Fetches a single inventory item for editing.
+ *
+ * Returns catalog attributes, pricing, and assignment hints to populate admin
+ * edit dialogs. Ensures the caller has inventory privileges before emitting
+ * JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_item_by_barcode.php
+++ b/ajax/get_item_by_barcode.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * POS barcode lookup endpoint.
+ *
+ * Searches for active items assigned to the current store by barcode, enforces
+ * stock availability, and returns pricing information for the POS cart.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_maintenance.php
+++ b/ajax/get_maintenance.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Maintenance schedule listing endpoint.
+ *
+ * Returns upcoming and overdue maintenance tasks with recurrence data for the
+ * admin maintenance module, applying search filters and enforcing permissions.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_maintenance_history.php
+++ b/ajax/get_maintenance_history.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Maintenance history timeline endpoint.
+ *
+ * Supplies paginated historical records per asset or schedule, enabling the UI
+ * to render maintenance timelines with technician notes and costs.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_maintenance_history_entry.php
+++ b/ajax/get_maintenance_history_entry.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Retrieves a single maintenance history entry.
+ *
+ * Used to populate detail modals with technician notes, costs, and attachments
+ * for review or editing. Restricted to authorized maintenance personnel.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_maintenance_schedule.php
+++ b/ajax/get_maintenance_schedule.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Fetches maintenance schedule metadata.
+ *
+ * Provides recurrence rules and related asset information when creating work
+ * orders from maintenance plans. Only accessible to authorized maintenance
+ * users and returns JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_purchase_order.php
+++ b/ajax/get_purchase_order.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Retrieves a single purchase order with line items.
+ *
+ * Populates the purchase order edit modal by returning header, supplier, and
+ * item details. Restricted to administrative users.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_purchase_orders.php
+++ b/ajax/get_purchase_orders.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Purchase order DataTable endpoint.
+ *
+ * Supports filtering by supplier, status, and date while returning paginated
+ * results for the procurement module. Ensures the caller is an administrator
+ * before outputting DataTables JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_salespersons.php
+++ b/ajax/get_salespersons.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Returns salesperson options for reporting filters.
+ *
+ * Retrieves active users assigned to the requested store so report pages can
+ * populate dropdowns. Accessible to authorized reporting roles and outputs
+ * JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_stock_by_store.php
+++ b/ajax/get_stock_by_store.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Aggregates stock quantities per store.
+ *
+ * Supports dashboard widgets and analytics by returning total stock counts for
+ * each store. Restricted to admins and warehouse roles.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_store.php
+++ b/ajax/get_store.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Fetches details for a single store.
+ *
+ * Used when editing store metadata in the admin interface. Validates
+ * permissions and returns the store row as JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_store_inventory.php
+++ b/ajax/get_store_inventory.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Store-level inventory feed.
+ *
+ * Provides item stock levels, barcode assignments, and status flags for a
+ * specific store. Used across store dashboards and adjustment dialogs while
+ * enforcing access control.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_store_inventory_enhanced.php
+++ b/ajax/get_store_inventory_enhanced.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Enhanced store inventory listing.
+ *
+ * Extends the base store inventory feed with additional computed columns for
+ * admin adjustments, feeding the `admin/store_inventory.php` interface.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_store_items_for_transfer.php
+++ b/ajax/get_store_items_for_transfer.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Lists source store items available for transfer.
+ *
+ * Validates available quantities, respects store assignments, and returns JSON
+ * so the transfer workflow can build shipments from eligible stock.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_stores.php
+++ b/ajax/get_stores.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Provides store listings for dropdowns and DataTables.
+ *
+ * Supports filtering by status and search term while enforcing admin access.
+ * Returns results in JSON suitable for the stores management page.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_subcategories.php
+++ b/ajax/get_subcategories.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Returns subcategory listings with optional category filter.
+ *
+ * Powers the admin subcategory DataTable by applying parent category and search
+ * filters, enforcing permissions, and returning DataTables-compatible JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_subcategory.php
+++ b/ajax/get_subcategory.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Fetches a single subcategory record for editing.
+ *
+ * Validates admin permissions, ensures the subcategory exists, and returns the
+ * row as JSON for edit modals.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_supplier.php
+++ b/ajax/get_supplier.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Retrieves a supplier record for editing.
+ *
+ * Populates the supplier modal with contact and status details. Access limited
+ * to admins, with responses returned as JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_suppliers.php
+++ b/ajax/get_suppliers.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Supplier listing endpoint.
+ *
+ * Serves DataTables requests from the supplier management UI, supporting search
+ * and status filters while restricting access to administrators.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_transfer_shipments.php
+++ b/ajax/get_transfer_shipments.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Lists transfer shipments for the transfer management dashboard.
+ *
+ * Returns shipment metadata, statuses, and related store information with
+ * pagination support. Restricted to users with transfer permissions and
+ * responses are DataTables-compatible JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_transfer_with_boxes.php
+++ b/ajax/get_transfer_with_boxes.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Provides detailed transfer shipment information including boxes and items.
+ *
+ * Supports deep inspection modals by returning shipment metadata alongside
+ * nested box and item arrays. Requires transfer management privileges.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_warehouse_boxes.php
+++ b/ajax/get_warehouse_boxes.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Warehouse box listing endpoint.
+ *
+ * Returns boxes filtered by type or container for reuse across warehouse and
+ * transfer workflows. Enforces warehouse/admin permissions and outputs JSON.
+ */
 require_once '../includes/session_config.php';
 
 // Start session if not already started

--- a/ajax/get_warehouse_inventory.php
+++ b/ajax/get_warehouse_inventory.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Aggregates warehouse inventory metrics.
+ *
+ * Summarizes loose items and boxed quantities to support warehouse dashboards
+ * and analytics. Restricted to warehouse-capable roles with JSON responses.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_work_order.php
+++ b/ajax/get_work_order.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Retrieves a single work order.
+ *
+ * Returns status, asset linkage, scheduling, and technician notes for editing
+ * or inspection within the work order module. Access is limited to maintenance
+ * roles.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/get_work_orders.php
+++ b/ajax/get_work_orders.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Work order listing endpoint.
+ *
+ * Delivers paginated work order data with filters for status, schedule, and
+ * assets to power the maintenance management grid. Requires maintenance
+ * privileges and emits DataTables JSON.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_adjust_stock.php
+++ b/ajax/process_adjust_stock.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Handles manual stock adjustment requests.
+ *
+ * Validates adjustment reasons, updates store inventory quantities, logs the
+ * movement in `inventory_transactions`, and returns JSON responses for the
+ * adjustment UI.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_asset.php
+++ b/ajax/process_asset.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Asset CRUD handler.
+ *
+ * Processes create, update, and delete actions from the asset management UI,
+ * validating inputs, enforcing CSRF tokens, and persisting changes before
+ * returning JSON feedback messages.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_boxes.php
+++ b/ajax/process_boxes.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Warehouse box CRUD endpoint.
+ *
+ * Manages creation, updating, and deletion of warehouse boxes, ensuring unique
+ * identifiers, managing container associations, and returning JSON results for
+ * the warehouse UI.
+ */
 require_once '../includes/session_config.php';
 
 // Start session if not already started

--- a/ajax/process_category.php
+++ b/ajax/process_category.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Category management endpoint.
+ *
+ * Handles add, update, and delete operations for product categories, including
+ * duplicate checks and CSRF validation, and responds with JSON status messages.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_container.php
+++ b/ajax/process_container.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Procurement container workflow engine.
+ *
+ * Processes container creation, updates, and status transitions, persists
+ * nested cost and item payloads, and calculates financial summaries. Restricted
+ * to admins and protected by CSRF validation, responding with JSON outcomes.
+ */
 // Turn off error reporting to prevent HTML output
 error_reporting(0);
 ini_set('display_errors', 0);

--- a/ajax/process_expense.php
+++ b/ajax/process_expense.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Expense submission and approval handler.
+ *
+ * Receives expense create/update/delete requests from both admin and store
+ * interfaces, manages receipt uploads, enforces permissions, and returns JSON
+ * confirmation messages.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_inventory.php
+++ b/ajax/process_inventory.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Inventory item CRUD endpoint.
+ *
+ * Handles creation, updates, and deletion of catalog items, including image
+ * uploads, barcode generation flags, and container linking. Enforces CSRF
+ * protection and returns JSON status messages.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_maintenance.php
+++ b/ajax/process_maintenance.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Maintenance schedule CRUD endpoint.
+ *
+ * Creates, updates, and deletes preventive maintenance plans, handling
+ * recurrence configuration, asset associations, and CSRF enforcement before
+ * returning JSON responses.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_maintenance_history.php
+++ b/ajax/process_maintenance_history.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Maintenance history entry handler.
+ *
+ * Records or updates completed maintenance actions, including technician notes,
+ * cost tracking, and attachment handling. Requires maintenance permissions and
+ * returns JSON feedback.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_purchase_order.php
+++ b/ajax/process_purchase_order.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Purchase order workflow endpoint.
+ *
+ * Handles PO creation and updates, persists header and line items, manages
+ * supplier associations, and enforces CSRF protection before returning JSON
+ * responses.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_return.php
+++ b/ajax/process_return.php
@@ -1,4 +1,12 @@
 <?php
+/**
+ * POS Return Processing Endpoint
+ * ------------------------------
+ * Reverses a previously issued invoice by creating a return header and line
+ * items, crediting stock back to the originating store, and updating the
+ * invoice payment status. This script mirrors the sale endpoint structure so
+ * that both features remain easy to audit.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';
@@ -27,6 +35,7 @@ $original_invoice_id = intval($_POST['original_invoice_id'] ?? 0);
 $return_reason = trim($_POST['return_reason'] ?? '');
 $return_type = $_POST['return_type'] ?? 'partial';
 $notes = trim($_POST['notes'] ?? '');
+// Items may arrive as a JSON string when posted via XHR
 $items = $_POST['items'] ?? [];
 if (is_string($items)) {
     $decoded = json_decode($items, true);

--- a/ajax/process_stock_transfer.php
+++ b/ajax/process_stock_transfer.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Generic stock transfer processor.
+ *
+ * Executes warehouse-to-store and store-to-store transfers by validating stock
+ * levels, adjusting inventory, creating shipment records, and returning JSON
+ * responses for the transfer UIs.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_store.php
+++ b/ajax/process_store.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Store administration endpoint.
+ *
+ * Handles create, update, and delete actions for store records, managing
+ * manager assignments and enforcing CSRF protection before returning JSON
+ * messages.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_store_inventory.php
+++ b/ajax/process_store_inventory.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Store inventory adjustment handler.
+ *
+ * Applies manual stock changes at the store level, updates barcode assignments
+ * and minimum stock thresholds, and logs adjustments before returning JSON
+ * responses.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_store_items.php
+++ b/ajax/process_store_items.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Admin-focused store item management handler.
+ *
+ * Persists item updates originating from `admin/store_items.php`, including
+ * store assignment adjustments, localized fields, and image management. Enforces
+ * CSRF protection and returns JSON outcomes.
+ */
 require_once '../includes/session_config.php';
 
 // Start session if not already started

--- a/ajax/process_store_to_store_transfer.php
+++ b/ajax/process_store_to_store_transfer.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Store-to-store transfer processor.
+ *
+ * Validates source availability, activates destination assignments, adjusts
+ * inventory for both stores, and records shipment metadata before responding
+ * with JSON used by the transfer workflow.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_subcategory.php
+++ b/ajax/process_subcategory.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Subcategory management endpoint.
+ *
+ * Supports CRUD operations on subcategories, ensuring parent category
+ * integrity, enforcing CSRF protection, and returning JSON messages to the UI.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_supplier.php
+++ b/ajax/process_supplier.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Supplier CRUD handler.
+ *
+ * Processes add, update, and delete actions for suppliers, including contact
+ * details and status updates, while enforcing admin-only access and CSRF
+ * validation before returning JSON responses.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_transfer_shipment.php
+++ b/ajax/process_transfer_shipment.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Transfer shipment finalization endpoint.
+ *
+ * Records outbound and inbound box movements, updates shipment statuses, and
+ * logs inventory transactions for transfer workflows. Returns JSON feedback to
+ * the UI.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/process_work_order.php
+++ b/ajax/process_work_order.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Work order lifecycle handler.
+ *
+ * Supports creation, updates, and closure of work orders, managing technician
+ * feedback, scheduling data, and status transitions before responding with JSON
+ * messages.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/search_items.php
+++ b/ajax/search_items.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * POS item search endpoint.
+ *
+ * Provides text-based lookup across item codes and names scoped to the current
+ * store, returning match data for the POS quick search modal.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/store_expenses.php
+++ b/ajax/store_expenses.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Store expense listing endpoint.
+ *
+ * Returns DataTables-formatted expense records for the current store with date
+ * and status filters, enabling store managers to review submissions.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/store_invoices.php
+++ b/ajax/store_invoices.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Store invoice listing endpoint.
+ *
+ * Supplies the store invoice page with paginated invoice data filtered by
+ * status and date range, ensuring results are scoped to the logged-in store.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/store_reports.php
+++ b/ajax/store_reports.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Store reporting data provider.
+ *
+ * Aggregates sales, inventory, and expense statistics for the current store
+ * over optional date ranges, returning JSON consumed by the store reports UI.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/store_returns.php
+++ b/ajax/store_returns.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Store returns listing endpoint.
+ *
+ * Provides return records initiated by the current store with status and date
+ * filters, allowing managers to audit return history.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/ajax/verify_manager_password.php
+++ b/ajax/verify_manager_password.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * POS secondary authorization check.
+ *
+ * Validates a manager’s password to approve sensitive POS actions initiated by
+ * salespersons. Returns JSON flags indicating whether the action may proceed.
+ */
 require_once 'ajax_session_init.php';
 require_once '../includes/db.php';
 require_once '../includes/functions.php';

--- a/assets/js/admin_dashboard.js
+++ b/assets/js/admin_dashboard.js
@@ -1,3 +1,17 @@
+/**
+ * Admin dashboard controller.
+ *
+ * Responsibilities:
+ * - Fetch top-level KPI metrics, recent sales activity, and low-stock warnings for the admin landing page.
+ * - Populate Bootstrap cards and DataTable bodies with formatted values so the PHP template only needs empty markup placeholders.
+ *
+ * Dependencies:
+ * - jQuery for DOM readiness, Ajax transport, and DOM mutations.
+ * - `../ajax/admin_dashboard.php` which accepts an `action` flag (`stats`, `recent_sales`, `low_stock`) and returns JSON payloads.
+ *
+ * Side effects:
+ * - Mutates `#stat*` counters and `<tbody>` elements in the dashboard tables once the asynchronous calls complete.
+ */
 $(document).ready(function() {
     function loadStats() {
         $.ajax({

--- a/assets/js/admin_expenses.js
+++ b/assets/js/admin_expenses.js
@@ -1,3 +1,16 @@
+/**
+ * Admin expenses management UI controller.
+ *
+ * Responsibilities:
+ * - Drive the admin expenses DataTable by querying `../ajax/process_expense.php` with read-only filters.
+ * - Handle add/edit modal lifecycle including file upload previews, default values, and POST submission to the same endpoint.
+ * - Provide inline approval/rejection controls for pending expenses so administrators can moderate spending.
+ *
+ * Dependencies:
+ * - jQuery for event binding, Ajax requests, and DOM manipulation.
+ * - Bootstrap modals for the add/edit dialog and toasts supplied elsewhere in the layout for success feedback.
+ * - `../ajax/process_expense.php` which supports `action=list|add|edit|approve|reject` payloads and returns JSON responses.
+ */
 $(document).ready(function() {
     function loadAdminExpenses() {
         const params = {

--- a/assets/js/admin_users.js
+++ b/assets/js/admin_users.js
@@ -1,3 +1,16 @@
+/**
+ * Admin user management controller.
+ *
+ * Responsibilities:
+ * - Fetch, filter, and render the administrator user list table with action buttons for CRUD operations.
+ * - Drive the add/edit modal by hydrating form fields from the table row and submitting to `../ajax/admin_users.php`.
+ * - Handle destructive flows such as delete and password resets with confirmation prompts and Ajax status feedback.
+ *
+ * Dependencies:
+ * - jQuery for event delegation, Ajax calls, and dynamic form manipulation.
+ * - Bootstrap modals and SweetAlert (wired in `script.js`) for modal dialogs and confirmation toasts.
+ * - `../ajax/admin_users.php` which responds to `list`, `create`, `update`, `delete`, and `reset_password` actions.
+ */
 $(document).ready(function() {
     function loadUsers() {
         const params = {

--- a/assets/js/assets.js
+++ b/assets/js/assets.js
@@ -1,5 +1,15 @@
 /**
- * Assets Management JavaScript
+ * Admin asset catalogue controller.
+ *
+ * Responsibilities:
+ * - Initialize the server-side DataTable for the asset list with filter propagation and CSRF protection.
+ * - Handle CRUD modal workflows (add/edit/delete) including client-side validation and SweetAlert confirmations.
+ * - Provide UX helpers such as formatted warranty status, previewing uploaded images, and resetting forms.
+ *
+ * Dependencies:
+ * - jQuery and DataTables for DOM manipulation and grid rendering.
+ * - SweetAlert for error/confirmation dialogs, Bootstrap modals for the CRUD UI, and `formatDate` helper defined at bottom of file.
+ * - Backend endpoints: `../ajax/get_assets.php` for listings and `../ajax/process_asset.php` for mutations.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/barcode-render.js
+++ b/assets/js/barcode-render.js
@@ -1,4 +1,15 @@
-// assets/js/barcode-render.js
+/**
+ * Barcode preview and print helper for the admin barcode console.
+ *
+ * Responsibilities:
+ * - Read dataset attributes from `#barcodeArea` to determine the symbology, format, and number of copies to render.
+ * - Stream HTML/SVG barcode markup from `barcode_image.php` via the Fetch API and inject multiple print-ready panels.
+ * - Provide a lightweight print dialog that waits for all images to load before invoking `window.print()` in a popup.
+ *
+ * Dependencies:
+ * - Native browser APIs (Fetch, DOM) – no jQuery requirements.
+ * - Server endpoint `barcode_image.php` which returns the generated barcode markup for the requested format.
+ */
 
 document.addEventListener('DOMContentLoaded', function() {
     const barcodeArea = document.getElementById('barcodeArea');

--- a/assets/js/boxes.js
+++ b/assets/js/boxes.js
@@ -1,5 +1,14 @@
 /**
- * Warehouse Boxes Management JavaScript
+ * Warehouse box administration controller.
+ *
+ * Responsibilities:
+ * - Configure the server-side DataTable for warehouse boxes, inject filter criteria, and surface live summary statistics.
+ * - Manage nested detail rows that display item contents, and expose CRUD modals backed by `../ajax/process_boxes.php`.
+ * - Provide diagnostic logging hooks that help debug mismatched payloads when admins troubleshoot box data.
+ *
+ * Dependencies:
+ * - jQuery, DataTables (with responsive extension), and SweetAlert for confirmations.
+ * - Bootstrap modals for form presentation and backend endpoints `../ajax/get_boxes.php` (list) and `../ajax/process_boxes.php` (mutations).
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/categories.js
+++ b/assets/js/categories.js
@@ -1,5 +1,14 @@
 /**
- * Categories Management JavaScript
+ * Category administration controller.
+ *
+ * Responsibilities:
+ * - Initialize the category listing DataTable with expandable subcategory detail rows and filter propagation.
+ * - Manage the add/edit modal lifecycle, enforcing CSRF tokens, validation messages, and success toasts.
+ * - Handle deletion confirmation flow including modal prompts and server calls to `../ajax/process_category.php`.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, and SweetAlert for UI interactions.
+ * - Bootstrap modals plus backend endpoints `../ajax/get_categories.php` (listing) and `../ajax/process_category.php` (mutations).
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -1,5 +1,14 @@
 /**
- * Common JavaScript functions for Mali Inventory System
+ * Global UX bootstrap utilities shared across every page.
+ *
+ * Responsibilities:
+ * - Wire sidebar toggle behaviour (desktop collapse persistence, mobile overlay, keyboard shortcut) and broadcast events for dependent modules.
+ * - Initialize Bootstrap tooltips/popovers, DataTable defaults, AJAX form helpers, and sidebar menu interactions consumed by individual screens.
+ * - Provide cross-cutting helpers (`toggleSidebar`, `updateToggleIcon`, etc.) that other scripts call via the global scope.
+ *
+ * Dependencies:
+ * - jQuery for event handling and DOM manipulation, DataTables for shared grid defaults, and Bootstrap 5 JavaScript for tooltips/offcanvas components.
+ * - Local storage for persisting sidebar collapsed state between sessions.
  */
 
 // Initialize all common functionality when DOM is ready

--- a/assets/js/containers.js
+++ b/assets/js/containers.js
@@ -1,6 +1,14 @@
 /**
- * Simplified Container Management JavaScript
- * Single bulk mode with total weight and total price only
+ * Procurement container workflow controller.
+ *
+ * Responsibilities:
+ * - Coordinate all modal interactions for creating/updating containers, including bulk item entry, box linking, and duplicate code validation.
+ * - Maintain client-side collections (items, expenses, payments) to mirror the nested JSON payload expected by `../ajax/process_container.php`.
+ * - Surface analytics summaries (weights, totals, margin calculations) and debug tooling to help administrators verify imports.
+ *
+ * Dependencies:
+ * - jQuery and Bootstrap modals for event handling, SweetAlert for validation messaging, and Select2/Flatpickr where present in the markup.
+ * - Backend endpoints `../ajax/get_containers.php`, `../ajax/process_container.php`, and related item/analytics fetchers invoked throughout the file.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/debug.js
+++ b/assets/js/debug.js
@@ -1,0 +1,9 @@
+/**
+ * Optional development hooks.
+ *
+ * This file intentionally exports no runtime logic by default. Developers can
+ * temporarily place console logging helpers or instrumentation here while
+ * diagnosing DataTable payloads or modal lifecycle issues. Keeping the file in
+ * version control provides a predictable place for such tooling without mixing
+ * it into production-oriented bundles.
+ */

--- a/assets/js/inventory.js
+++ b/assets/js/inventory.js
@@ -1,5 +1,14 @@
 /**
- * Inventory Management JavaScript
+ * Admin inventory catalogue controller.
+ *
+ * Responsibilities:
+ * - Bootstrap the inventory DataTable with advanced filters, CSRF protection, and expandable detail rows for store assignments.
+ * - Drive add/edit/manage-store modal interactions, including barcode generation preview and status toggles.
+ * - Coordinate with the server to refresh statistics, handle import workflows, and sync the mobile card view produced by `mobile-responsive.js`.
+ *
+ * Dependencies:
+ * - jQuery, DataTables (responsive extension), SweetAlert, Bootstrap modals, and Select2 for dropdowns where applicable.
+ * - Backend endpoints: `../ajax/get_inventory.php` for listing, `../ajax/process_inventory.php` for CRUD, plus helper endpoints for store assignments and containers referenced deeper in the file.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/invoices.js
+++ b/assets/js/invoices.js
@@ -1,3 +1,15 @@
+/**
+ * Admin invoice browser controller.
+ *
+ * Responsibilities:
+ * - Initialize the invoices DataTable, propagate filter form values, and render payment status badges.
+ * - Bind filter submissions and row action buttons (view/export) to the appropriate AJAX endpoints and modals.
+ * - Display SweetAlert error messaging when the API returns failures so administrators receive immediate feedback.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, and Bootstrap modals.
+ * - Backend endpoints: `../ajax/get_invoices.php` for listing and `../ajax/get_invoice.php` for the modal detail fetch triggered further down in the script.
+ */
 $(document).ready(function() {
     if (window.invoicesTableInitialized) {
         // Already initialized, do nothing

--- a/assets/js/maintenance.js
+++ b/assets/js/maintenance.js
@@ -1,5 +1,14 @@
 /**
- * Maintenance Management JavaScript
+ * Preventive maintenance scheduler controller.
+ *
+ * Responsibilities:
+ * - Populate the maintenance schedule DataTable with filter parameters, CSRF tokens, and status badges highlighting overdue work.
+ * - Manage the add/edit schedule modal, including recurrence dropdowns, asset autocomplete wiring, and server submissions.
+ * - Coordinate follow-up actions such as generating work orders directly from a schedule row.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, Bootstrap modals, and Select2/autocomplete widgets referenced later in the file.
+ * - Backend endpoints: `../ajax/get_maintenance.php` (listing) and `../ajax/process_maintenance.php` (mutations).
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/maintenance_history.js
+++ b/assets/js/maintenance_history.js
@@ -1,5 +1,14 @@
 /**
- * Maintenance History Management JavaScript
+ * Maintenance history log controller.
+ *
+ * Responsibilities:
+ * - Render completed maintenance entries with filterable DataTable columns and contextual status badges.
+ * - Power the add/edit modal for logging technician notes, completion evidence, and file attachments.
+ * - Handle delete confirmations and refresh the grid after any mutation so audit trails remain current.
+ *
+ * Dependencies:
+ * - jQuery, DataTables (responsive), SweetAlert, Bootstrap modals, and datepicker widgets used within the modal forms.
+ * - Backend endpoints `../ajax/get_maintenance_history.php` (list) and `../ajax/process_maintenance_history.php` (CRUD).
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/mobile-responsive.js
+++ b/assets/js/mobile-responsive.js
@@ -1,6 +1,14 @@
 /**
- * Mobile Responsive JavaScript Enhancements for ETS System
- * Handles responsive behavior, table-to-card conversion, and mobile optimizations
+ * Responsive behaviour orchestrator.
+ *
+ * Responsibilities:
+ * - Detect viewport breakpoints/orientation changes and toggle between desktop tables and mobile-friendly card renderings.
+ * - Inject touch optimizations (larger hit targets, swipe helpers), step navigation, and collapsible sections for constrained screens.
+ * - Provide helper routines that other modules call to keep DataTables and card views synchronized during redraws.
+ *
+ * Dependencies:
+ * - jQuery for DOM traversal/manipulation and DataTables instances passed in from other scripts.
+ * - Bootstrap classes for responsive styling; no backend interaction.
  */
 
 class MobileResponsive {

--- a/assets/js/purchase_orders.js
+++ b/assets/js/purchase_orders.js
@@ -1,5 +1,14 @@
 /**
- * Purchase Orders Management JavaScript
+ * Purchase order administration controller.
+ *
+ * Responsibilities:
+ * - Populate the PO listing DataTable with filter-aware Ajax queries and badge formatting for lifecycle status.
+ * - Drive the PO modal workflow: adding headers, managing line items dynamically, and submitting JSON payloads to the server.
+ * - Integrate supplier autocomplete, container linkage, and document export actions exposed in the UI.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, Bootstrap modals, and Select2/autocomplete components.
+ * - Backend endpoints: `../ajax/get_purchase_orders.php` for listing and `../ajax/process_purchase_order.php` for mutations.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,6 +1,14 @@
 /**
- * Inventory & Maintenance Management System
- * Common JavaScript Functions
+ * Legacy global helpers bundled on most admin pages.
+ *
+ * Responsibilities:
+ * - Provide default DataTable initialization, Bootstrap datepicker wiring, and client-side validation rules for standard forms.
+ * - Offer reusable confirmation dialogs, tooltip/popover activation, and responsive sidebar tweaks for mobile layouts.
+ * - Expose utility functions (`showToast`, `showLoader`, etc.) consumed by feature-specific modules.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, Bootstrap, and flatpickr (or alternative datepicker) depending on the markup.
+ * - Works alongside `common.js` – this file focuses on component initialization while `common.js` manages layout chrome.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/store_expenses.js
+++ b/assets/js/store_expenses.js
@@ -1,3 +1,15 @@
+/**
+ * Store expense listing controller.
+ *
+ * Responsibilities:
+ * - Fetch store-level expenses filtered by date, category, and status from `../ajax/store_expenses.php`.
+ * - Render the results into the table body and provide placeholders for view/print actions.
+ * - Refresh the listing in response to filter submissions without reloading the page.
+ *
+ * Dependencies:
+ * - jQuery for event handling and AJAX; Bootstrap styling for table badges.
+ * - Backend endpoint `../ajax/store_expenses.php`.
+ */
 $(document).ready(function() {
     function loadExpenses() {
         const params = {

--- a/assets/js/store_invoices.js
+++ b/assets/js/store_invoices.js
@@ -1,3 +1,15 @@
+/**
+ * Store invoice list controller.
+ *
+ * Responsibilities:
+ * - Query `../ajax/store_invoices.php` for invoice summaries scoped to the current store and active filters.
+ * - Render payment status badges and action buttons for view/print features.
+ * - Refresh the table when filters change without requiring a full page reload.
+ *
+ * Dependencies:
+ * - jQuery for DOM handling; Bootstrap badge styling for status indicators.
+ * - Backend endpoint `../ajax/store_invoices.php`.
+ */
 $(document).ready(function() {
     function loadInvoices() {
         const params = {

--- a/assets/js/store_items.js
+++ b/assets/js/store_items.js
@@ -1,5 +1,14 @@
 /**
- * Store Items Management JavaScript (Inventory + Store Assignments)
+ * Store assignment management client.
+ *
+ * Responsibilities:
+ * - Provide modals for assigning inventory items to stores, including bulk assignment flows and search/filter utilities.
+ * - Synchronize selected item state with the main inventory DataTable (initialized in `inventory.js`).
+ * - Coordinate AJAX calls to `../ajax/process_store_items.php` to fetch assignments, persist changes, and report errors.
+ *
+ * Dependencies:
+ * - jQuery (for some selectors), Fetch API, Bootstrap modals, SweetAlert for error messaging, and global helpers like `showToast`.
+ * - Backend endpoint `../ajax/process_store_items.php` with actions such as `get_store_assignments`, `save_assignment`, and bulk variants.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/store_reports.js
+++ b/assets/js/store_reports.js
@@ -1,3 +1,15 @@
+/**
+ * Store reporting dashboard controller.
+ *
+ * Responsibilities:
+ * - Load sales, inventory, invoice, expense, and return summaries via `../ajax/store_reports.php` for the active store.
+ * - Render the returned datasets into Bootstrap tables/charts placeholders and handle empty/error messaging.
+ * - React to filter submissions (date ranges, payment types) to refresh the respective report sections.
+ *
+ * Dependencies:
+ * - jQuery for AJAX + DOM updates; Chart.js (where charts are rendered later in the file) for visualizations.
+ * - Backend endpoint `../ajax/store_reports.php` with `action` switches.
+ */
 $(document).ready(function() {
     // --- Sales Report ---
     function loadSalesReport() {

--- a/assets/js/store_returns.js
+++ b/assets/js/store_returns.js
@@ -1,3 +1,15 @@
+/**
+ * Store return listing controller.
+ *
+ * Responsibilities:
+ * - Retrieve return summaries for the active store via `../ajax/store_returns.php` with filter criteria.
+ * - Render result rows, status badges, and action buttons for future detail/print functionality.
+ * - Refresh the table when filter forms submit without a full reload.
+ *
+ * Dependencies:
+ * - jQuery for AJAX/event handling and Bootstrap for styling.
+ * - Backend endpoint `../ajax/store_returns.php`.
+ */
 $(document).ready(function() {
     function loadReturns() {
         const params = {

--- a/assets/js/stores.js
+++ b/assets/js/stores.js
@@ -1,3 +1,15 @@
+/**
+ * Store directory management controller.
+ *
+ * Responsibilities:
+ * - Initialize the stores DataTable with CSRF-protected server-side queries and responsive layout.
+ * - Drive add/edit/delete workflows including manager assignment dropdowns and POS shortcut links.
+ * - Use SweetAlert for confirmation prompts and integrate with `../ajax/process_store.php` for mutations.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, Bootstrap modals, and helper functions defined in `script.js`.
+ * - Backend endpoints `../ajax/get_stores.php` and `../ajax/process_store.php`, plus `../ajax/admin_users.php` for manager lists.
+ */
 $(document).ready(function() {
     const csrfToken = $('#csrf_token').val();
     // Initialize DataTable

--- a/assets/js/subcategories.js
+++ b/assets/js/subcategories.js
@@ -1,5 +1,14 @@
 /**
- * Subcategories Management JavaScript
+ * Subcategory administration controller.
+ *
+ * Responsibilities:
+ * - Initialize the subcategory DataTable with parent-category filters and item counts.
+ * - Manage add/edit modals, cascading category dropdowns, and delete confirmations via SweetAlert.
+ * - Call `../ajax/process_subcategory.php` to persist changes and reload the grid on success.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, Bootstrap modals.
+ * - Backend endpoints `../ajax/get_subcategories.php` and `../ajax/process_subcategory.php`.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/suppliers.js
+++ b/assets/js/suppliers.js
@@ -1,5 +1,14 @@
 /**
- * Suppliers Management JavaScript
+ * Supplier directory controller.
+ *
+ * Responsibilities:
+ * - Initialize the suppliers DataTable with filters, contact links, and status badges.
+ * - Manage modals for viewing/editing supplier information and handle deletions via SweetAlert confirmations.
+ * - Submit CRUD operations to `../ajax/process_supplier.php` and refresh the grid on success.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, Bootstrap modals.
+ * - Backend endpoints `../ajax/get_suppliers.php` and `../ajax/process_supplier.php`.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/assets/js/work_orders.js
+++ b/assets/js/work_orders.js
@@ -1,5 +1,14 @@
 /**
- * Work Orders Management JavaScript
+ * Maintenance work order controller.
+ *
+ * Responsibilities:
+ * - Render the work order queue with server-side filtering and badge styling for priority/status.
+ * - Manage modals for creating, updating, and closing work orders, including technician assignments and attachment uploads.
+ * - Communicate with `../ajax/process_work_order.php` for persistence and refresh the DataTable after changes.
+ *
+ * Dependencies:
+ * - jQuery, DataTables, SweetAlert, Bootstrap modals, and flatpickr for scheduling fields.
+ * - Backend endpoints: `../ajax/get_work_orders.php`, `../ajax/get_work_order.php`, and `../ajax/process_work_order.php`.
  */
 
 document.addEventListener('DOMContentLoaded', function() {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Global helper library for ETS System Fashion.
+ * ---------------------------------------------
+ * Centralizes authentication helpers, store/role authorization checks,
+ * formatting utilities, and the majority of reusable inventory and transfer
+ * routines. The POS and admin portals both include this file to keep their
+ * business rules aligned. As a result, functions should remain side-effect
+ * free unless explicitly updating the database.
+ */
+
 // Turn off error reporting to prevent HTML output
 error_reporting(0);
 ini_set('display_errors', 0);
@@ -77,6 +87,16 @@ function can_access_store($store_id) {
 }
 
 // Utility functions
+/**
+ * Normalize potentially unsafe user input before storing/using it.
+ *
+ * While prepared statements protect SQL queries, many pages echo the raw
+ * values back to the browser. This helper applies basic trimming and HTML
+ * escaping to stop accidental injection of markup.
+ *
+ * @param string $data
+ * @return string
+ */
 function sanitize_input($data) {
     $data = trim($data);
     $data = stripslashes($data);
@@ -84,6 +104,16 @@ function sanitize_input($data) {
     return $data;
 }
 
+/**
+ * Issue an HTTP redirect and terminate execution.
+ *
+ * Wrapping the `header()` call keeps controllers concise and centralizes the
+ * `exit()` call so future logging hooks can be introduced without touching
+ * every usage site.
+ *
+ * @param string $url
+ * @return void
+ */
 function redirect($url) {
     header("Location: $url");
     exit();

--- a/store/dashboard.php
+++ b/store/dashboard.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Store Manager Dashboard
+ * -----------------------
+ * Acts as the landing page for store managers, summarizing inventory health,
+ * sales, returns, and expenses relevant to the current store. The page inherits
+ * authentication, localization, and layout from the shared header, while
+ * `assets/js/store_reports.js` and related scripts populate cards and tables via
+ * endpoints such as `ajax/store_reports.php` and `ajax/store_invoices.php`.
+ */
 require_once '../includes/header.php';
 if (!is_store_manager()) {
     redirect('../index.php');

--- a/store/expenses.php
+++ b/store/expenses.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Store Expense Entry & Tracking
+ * ------------------------------
+ * Allows store managers to submit operating expenses, attach receipts, and
+ * monitor approval status without accessing the admin console. Authentication
+ * and localization are inherited from the shared header, while the interactive
+ * form and listing are orchestrated by `assets/js/store_expenses.js` calling
+ * `ajax/store_expenses.php` for listings and `ajax/process_expense.php` for
+ * submissions.
+ */
 require_once '../includes/header.php';
 if (!is_store_manager()) {
     redirect('../index.php');

--- a/store/invoices.php
+++ b/store/invoices.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Store-Level Invoice Browser
+ * ---------------------------
+ * Lets store managers audit the invoices generated within their location,
+ * including statuses, payments, and return activity. The page reuses the shared
+ * header to enforce authentication, renders date/status filters, and leverages
+ * `assets/js/store_invoices.js` to load data from `ajax/store_invoices.php` and
+ * fetch detailed invoice breakdowns for modal display.
+ */
 require_once '../includes/header.php';
 if (!is_store_manager()) {
     redirect('../index.php');

--- a/store/pos.php
+++ b/store/pos.php
@@ -1,4 +1,16 @@
 <?php
+/**
+ * Point-of-Sale Terminal
+ * ----------------------
+ * Powers in-store sales and operational workflows for managers and sales
+ * personnel. The script enforces role-based access, locks the interface to the
+ * French locale, ensures the active store context, and seeds a CSRF token for
+ * AJAX calls. The sprawling front-end logic lives in `assets/js/pos.js`, which
+ * communicates with endpoints such as `ajax/get_item_by_barcode.php`,
+ * `ajax/process_sale.php`, `ajax/process_return.php`, and
+ * `ajax/store_expenses.php` to manage carts, payments, returns, expenses, and
+ * shift reports.
+ */
 require_once '../includes/header.php';
 if (!is_store_manager() && !is_sales_person()) {
     redirect('../index.php');

--- a/store/reports.php
+++ b/store/reports.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Store Reporting Suite
+ * ---------------------
+ * Provides store managers with curated reports on sales, inventory, invoices,
+ * and expenses without requiring admin access. After leveraging the shared
+ * header for authentication, the page exposes tabbed report layouts that are
+ * populated via `assets/js/store_reports.js` calling
+ * `ajax/store_reports.php`, `ajax/store_invoices.php`, and
+ * `ajax/store_expenses.php` depending on the active tab.
+ */
 require_once '../includes/header.php';
 if (!is_store_manager()) {
     redirect('../index.php');

--- a/store/returns.php
+++ b/store/returns.php
@@ -1,4 +1,14 @@
 <?php
+/**
+ * Store Return Tracking
+ * ---------------------
+ * Enables store managers to audit and follow up on return requests initiated in
+ * the POS or back office. By inheriting authentication from the shared header,
+ * the page restricts visibility to the current store and renders filters plus
+ * DataTables managed by `assets/js/store_returns.js`. Data is sourced from
+ * `ajax/store_returns.php`, while deep return operations interact with
+ * `ajax/process_return.php` and related POS endpoints.
+ */
 require_once '../includes/header.php';
 if (!is_store_manager()) {
     redirect('../index.php');


### PR DESCRIPTION
## Summary
- add detailed module-level docblocks to each JavaScript controller under assets/js so maintainers understand responsibilities, dependencies, and server endpoints
- document the optional debug helper stub to clarify its intended use during troubleshooting
- add file-level PHPDoc headers to every admin and store PHP module describing page responsibilities, required roles, and the AJAX endpoints or scripts they collaborate with

## Testing
- `for f in $(git diff --name-only HEAD^); do php -l $f; done`


------
https://chatgpt.com/codex/tasks/task_e_68cd21fed7308323bbf250d2ea697a7a